### PR TITLE
Fix cask zap path

### DIFF
--- a/fiscript.rb
+++ b/fiscript.rb
@@ -16,5 +16,5 @@ cask 'fiscript' do
               '~/Library/Containers/com.Mortennn.FiScript.Finder-Extension',
               '~/Library/Group Containers/group.Mortennn.FiScript',
               '~/Library/Group Containers/sharedContainerID.container',
-              '~/Library/Group\ Containers/group.Mortennn.FiScript']
+              '~/Library/Group Containers/group.Mortennn.FiScript']
 end

--- a/fiscript.rb
+++ b/fiscript.rb
@@ -1,7 +1,7 @@
 cask 'fiscript' do
   version '1.0.1'
   sha256 'a622526479338a151c42f57b04717902555b33aad06abba249c8a4bb0554a0ed'
-  
+
   url 'https://github.com/Mortennn/FiScript/releases/download/v1.0.1/FiScript.zip'
   name 'FiScript'
   homepage 'https://github.com/Mortennn/FiScript'
@@ -10,5 +10,11 @@ cask 'fiscript' do
 
   app 'FiScript.app'
 
-  zap trash: ['~/Library/Application Scripts/com.Mortennn.FiScript', '~/Library/Application Scripts/com.Mortennn.FiScript.Finder-Extension', '~/Library/Containers/com.Mortennn.FiScript', '~/Library/Containers/com.Mortennn.FiScript.Finder-Extension', '~/Library/Group Containers/group.Mortennn.FiScript', '~/Library/Group Containers/sharedContainerID.container', '~/Library/Group\ Containers/group.Mortennn.FiScript']
+  zap trash: ['~/Library/Application Scripts/com.Mortennn.FiScript',
+              '~/Library/Application Scripts/com.Mortennn.FiScript.Finder-Extension',
+              '~/Library/Containers/com.Mortennn.FiScript',
+              '~/Library/Containers/com.Mortennn.FiScript.Finder-Extension',
+              '~/Library/Group Containers/group.Mortennn.FiScript',
+              '~/Library/Group Containers/sharedContainerID.container',
+              '~/Library/Group\ Containers/group.Mortennn.FiScript']
 end


### PR DESCRIPTION
This pull request replaces the path name containing `Group\ Containers` with `Group Containers`.