### PR TITLE
Escape directory path on iTerm actions

### DIFF
--- a/Common/DefaultActions.swift
+++ b/Common/DefaultActions.swift
@@ -135,7 +135,7 @@ public class DefaultActions {
             tell the current window
             activate current session
             tell current session
-            write text "cd " & $PATH & "; clear"
+            write text "cd " & quoted form of $PATH & "; clear"
             end tell
             end tell
             end tell
@@ -144,7 +144,7 @@ public class DefaultActions {
             tell application "iTerm"
             tell current window
             tell current session
-            write text "cd " & $PATH & "; clear"
+            write text "cd " & quoted form of $PATH & "; clear"
             end tell
             end tell
             end tell
@@ -176,7 +176,7 @@ public class DefaultActions {
                         activate current session
                         launch session "Default Session"
                         tell the last session
-                            write text "cd " & $PATH & "; clear"
+                            write text "cd " & quoted form of $PATH & "; clear"
                         end tell
                     end tell
                 end tell


### PR DESCRIPTION
[This issue](https://github.com/Mortennn/FiScript/issues/6) reports that `Open iTerm *` actions are not working on directories with whitespace in the path. This PR address this problem by escaping the path on the `cd` command.